### PR TITLE
Fix admin table status display

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -35,7 +35,8 @@ async function loadOrders() {
       row.appendChild(idCell);
 
       const statusCell = document.createElement('td');
-      statusCell.textContent = order.status;
+      const statusText = statuses[order.statusIndex] || order.status || '';
+      statusCell.textContent = statusText;
       row.appendChild(statusCell);
 
       tbody.appendChild(row);


### PR DESCRIPTION
## Summary
- ensure the order table uses the status index

## Testing
- `npm --prefix frontend test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684059dd28fc832882d1997cc890edf1